### PR TITLE
prePoll and postPoll fixes and simplifications

### DIFF
--- a/src/main/java/com/github/davidmoten/rx2/aws/Sqs.java
+++ b/src/main/java/com/github/davidmoten/rx2/aws/Sqs.java
@@ -121,9 +121,9 @@ public final class Sqs {
         private Optional<Callable<AmazonS3>> s3 = Optional.empty();
         private Optional<String> bucketName = Optional.empty();
         private Optional<Flowable<Integer>> waitTimesSeconds = Optional.empty();
-        private Consumer<? super String> logger = (String s) -> {};
+        private Consumer<? super String> logger = x -> {};
         private Runnable prePoll = () -> {};
-        private Consumer<? super Optional<Throwable>> postPoll = (Optional<Throwable> t) -> {};
+        private Consumer<? super Optional<Throwable>> postPoll = x -> {};
 
         SqsBuilder(SqsQueue queue) {
             Preconditions.checkNotNull(queue);
@@ -249,10 +249,10 @@ public final class Sqs {
                 .concatWith( //
                         Flowable.fromCallable(() -> sqsMessages(service, 0, prePoll, postPoll)) //
                                 .repeat()) //
-                .takeWhile(list -> !list.isEmpty()) //
+                .takeWhile(x -> !x.isEmpty()) //
                 .flatMapIterable(x -> x) //
-                .filter(opt -> opt.isPresent()) //
-                .map(opt -> opt.get());
+                .filter(Optional::isPresent) //
+                .map(Optional::get);
     }
     
     private static List<Message> messages(Service service, int waitTimeSeconds, Runnable prePoll,

--- a/src/main/java/com/github/davidmoten/rx2/aws/Sqs.java
+++ b/src/main/java/com/github/davidmoten/rx2/aws/Sqs.java
@@ -327,16 +327,11 @@ public final class Sqs {
             while (!next.isPresent()) {
                 while (q.isEmpty()) {
                     logger.accept("long polling for messages on queue=" + service.queueUrl);
-                    prePoll.run();
-                    List<Message> list;
-                    try {
-                        list = service.sqs.receiveMessage(request).getMessages();
-                    } catch(Throwable t) {
-                        postPoll.accept(Optional.of(t));
-                        throw t;
-                    }
+                    List<Message> list = messages( //
+                            () -> service.sqs.receiveMessage(request).getMessages(), //
+                            prePoll, // 
+                            postPoll);
                     q.addAll(list);
-                    postPoll.accept(Optional.empty());
                 }
                 final Message message = q.poll();
                 next = getNextMessage(message, service);

--- a/src/main/java/com/github/davidmoten/rx2/aws/Sqs.java
+++ b/src/main/java/com/github/davidmoten/rx2/aws/Sqs.java
@@ -7,7 +7,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;

--- a/src/test/java/com/github/davidmoten/rx2/aws/AwsClientsTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/aws/AwsClientsTest.java
@@ -6,7 +6,6 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.regions.Regions;
 import com.github.davidmoten.junit.Asserts;
-import com.github.davidmoten.rx2.aws.AwsClients;
 
 public class AwsClientsTest {
 

--- a/src/test/java/com/github/davidmoten/rx2/aws/SqsMessageTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/aws/SqsMessageTest.java
@@ -13,8 +13,6 @@ import org.mockito.Mockito;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.sqs.AmazonSQSClient;
 import com.amazonaws.services.sqs.model.DeleteMessageResult;
-import com.github.davidmoten.rx2.aws.SqsMessage;
-import com.github.davidmoten.rx2.aws.Util;
 import com.github.davidmoten.rx2.aws.SqsMessage.Client;
 
 public class SqsMessageTest {

--- a/src/test/java/com/github/davidmoten/rx2/aws/SqsTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/aws/SqsTest.java
@@ -295,7 +295,6 @@ public final class SqsTest {
         Sqs.sendToQueueUsingS3(sqs, "queueUrl", s3, "bucket", new byte[] { 1, 2 });
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void ensureIfSendToSqsFailsThatS3ObjectIsDeleted() {
         final AmazonSQSClient sqs = Mockito.mock(AmazonSQSClient.class);

--- a/src/test/java/com/github/davidmoten/rx2/aws/SqsTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/aws/SqsTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -53,9 +54,12 @@ public final class SqsTest {
                 list.add(msg);
             }
         };
+        List<String> events = new ArrayList<>();
         Sqs.queueName(queueName) //
                 .sqsFactory(() -> sqs) //
                 .logger(logger)
+                .prePoll(() -> events.add("prePoll")) //
+                .postPoll(e -> events.add("postPoll")) //
                 .messages() //
                 .map(m -> m.message()) //
                 .doOnError(Throwable::printStackTrace) //
@@ -70,6 +74,7 @@ public final class SqsTest {
         inorder.verify(sqs, Mockito.times(1)).shutdown();
         inorder.verifyNoMoreInteractions();
         assertEquals(Arrays.asList("long polling for messages on queue=queue"), list);
+        assertEquals(Arrays.asList("prePoll", "postPoll"), events);
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/com/github/davidmoten/rx2/aws/SqsTest.java
+++ b/src/test/java/com/github/davidmoten/rx2/aws/SqsTest.java
@@ -398,4 +398,45 @@ public final class SqsTest {
             assertEquals(Arrays.asList("prePoll"), events);
         }
     }
+    
+    @Test
+    public void testUncheckedCall() {
+        assertEquals(1, (int) Sqs.uncheckedCall(() -> 1));   
+    }
+    
+    @Test
+    public void testUncheckedCallThrowsRuntimeException() {
+        try {
+            Sqs.uncheckedCall(() -> {
+                throw new IllegalArgumentException("boo");
+            });
+            Assert.fail();
+        } catch (RuntimeException e) {
+            assertEquals("boo", e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testUncheckedCallThrowsError() {
+        try {
+            Sqs.uncheckedCall(() -> {
+                throw new Error("boo");
+            });
+            Assert.fail();
+        } catch (Error e) {
+            assertEquals("boo", e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testUncheckedCallThrowsCheckedException() {
+        try {
+            Sqs.uncheckedCall(() -> {
+                throw new Exception("boo");
+            });
+            Assert.fail();
+        } catch (RuntimeException e) {
+            assertEquals("boo", e.getCause().getMessage());
+        }
+    }
 }


### PR DESCRIPTION
#4 needed a bit of a cleanup but also 
* the `createFlowablePolling` method was missing `prePoll` and `postPoll` calls for first `receiveMessages` call
* minimize side-effects if `prePoll` or `postPoll` throw (for example an exception thrown by `postPoll` would have been caught and submitted to `postPoll` again)
* add unit tests of prePoll and postPoll events
